### PR TITLE
Added Support for PupilDiameter Parameter

### DIFF
--- a/VarjoTrackingModule.cs
+++ b/VarjoTrackingModule.cs
@@ -57,6 +57,8 @@ namespace VRCFTVarjoModule
             {
                 data.EyesDilation = (float)calculateEyeDilation(ref pupilSize);
             }
+            // Set the Pupil Diameter anyways
+            data.EyesPupilDiameter = (float)(pupilSize > 10 ? 1 : pupilSize / 10);
         }
 
         // This Function is used to calculate the Eye Dilation based on the lowest and highest measured Pupil Size


### PR DESCRIPTION
A recent PR to the VRCFT Repo added support for a new "Pupil Diameter" Parameter.
Trying to stay ahead of the curve, I've already added support for that parameter in this PR.
It should behave exactly the same way as it does with SRanipal in VRCFT 💯 

Note: It may not be the wisest giving this a Version tag until VRCFT has added one for the change there